### PR TITLE
Update dependency name to avoid naming mismatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Add this to your application's `shard.yml`:
 
 ```yaml
 dependencies:
-  file_atomic_write:
+  atomic_write:
     github: chris-huxtable/atomic_write.cr
 ```
 


### PR DESCRIPTION
This resolves the "Error shard name (atomic_write) doesn't match dependency name (file_atomic_write)" error that arises from following the README exactly. As someone new to Crystal, it wasn't immediately obvious how to fix the issue.